### PR TITLE
[Feature]: GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
         target="_blank">
         <img 
             src="assets/logo.png" 
-            alt="Mein Bild" 
+            alt="Logo Horus" 
             width="200" 
             height="200">
         </img>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Horus</title>
+  </head>
+  <body>
+    <div align="center">
+        <a 
+        target="_blank" 
+        href="https://github.com/sergej-stk/horus">
+            <img 
+                src="../assets/logo.png"
+                alt="Logo Horus" 
+                width="200" 
+                height="200">
+            </img>
+        </a>
+
+        <h1>
+            Horus
+        </h1>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Feature Description
I would like to add GitHub Pages to my project in order to create and host a documentation site. This would allow users and contributors to easily access detailed information about the project, including setup instructions, usage guidelines, and API documentation.

## Use Cases
- **Project Documentation:** A place where users can find comprehensive guides on how to set up and use the project.
- **API Reference:** A dedicated section to document the API endpoints, request/response examples, and authentication methods.
- **Contributors Guide:** A space for potential contributors to find out how to contribute to the project, report issues, and submit pull requests.

## Expected Behavior
The GitHub Pages site should be automatically deployed from the project's repository. It will include a clean, user-friendly interface for the documentation that can be easily updated through the repository. The site will be accessible via a URL like `https://username.github.io/project-name`.

## Alternatives
- **External Documentation Hosting:** You could use an external service like ReadTheDocs or Netlify to host the documentation. However, GitHub Pages offers a more seamless integration with the GitHub repository.
- **Markdown Files in the Repository:** Keeping documentation as markdown files directly in the repository without hosting a separate site. This could be less user-friendly for people unfamiliar with GitHub.

## Additional Information
Using GitHub Pages for documentation is free and provides a simple way to integrate the documentation with the project’s GitHub repository. The documentation will be versioned alongside the project, ensuring it stays up-to-date with changes.